### PR TITLE
Fix RSpec definition

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--require spec_helper
+--format documentation

--- a/spec/htmllint_spec.rb
+++ b/spec/htmllint_spec.rb
@@ -1,5 +1,3 @@
-require File.expand_path("spec_helper", __dir__)
-
 module Danger
   describe "with Dangerfile" do
     before do

--- a/spec/htmllint_spec.rb
+++ b/spec/htmllint_spec.rb
@@ -1,4 +1,4 @@
-module Danger
+RSpec.describe 'Danger' do
   describe "with Dangerfile" do
     before do
       @dangerfile = testing_dangerfile

--- a/spec/htmllint_spec.rb
+++ b/spec/htmllint_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Danger' do
       allow(@htmllint.git).to receive(:deleted_files).and_return([])
     end
 
-    describe ".parse" do
+    describe "#parse" do
       subject(:errors) do
         @htmllint.send(:parse, fixture)
       end
@@ -57,7 +57,7 @@ RSpec.describe 'Danger' do
       end
     end
 
-    describe ".htmllint_command" do
+    describe "#htmllint_command" do
       subject(:command) do
         @htmllint.send(:htmllint_command, "./node_modules/.bin/htmllint", target_files)
       end
@@ -97,7 +97,7 @@ RSpec.describe 'Danger' do
       end
     end
 
-    describe ".target_files" do
+    describe "#target_files" do
       subject(:targets) do
         @htmllint.send(:target_files)
       end


### PR DESCRIPTION
- Move `require 'spec_helper'` to `.rspec` file
- Fix RSpec definition as `RSpec.describe`
- Fix Ruby method notation